### PR TITLE
Remove `GET /api/jobs` endpoint in favour of `GET /api/projects/.../jobs`

### DIFF
--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -92,7 +92,6 @@ pub async fn make_app(server: &Server) -> Result<highnoon::App<State>> {
 
     // job
     app.at("/api/jobs")
-        .get(job::get_by_name)
         .post(job::create)
         .put(job::create);
     app.at("/api/jobs/:id")

--- a/src/server/api/job.rs
+++ b/src/server/api/job.rs
@@ -162,34 +162,6 @@ struct GetJob {
     pub paused: bool,
 }
 
-pub async fn get_by_name(req: Request<State>) -> highnoon::Result<impl Responder> {
-    let q = req.query::<QueryJob>()?;
-
-    let maybe_job: Option<GetJob> = sqlx::query_as(
-        "SELECT
-            j.id AS id,
-            j.name AS name,
-            j.project_id AS project_id,
-            j.description AS description,
-            j.paused AS paused
-        FROM job j
-        JOIN project p ON j.project_id = p.id
-        WHERE j.name = $1
-        AND p.name = $2",
-    )
-    .bind(&q.name)
-    .bind(&q.project)
-    .fetch_optional(&req.get_pool())
-    .await?;
-
-    if let Some(job) = maybe_job {
-        auth::get().job(job.id, job.project_id).check(&req).await?;
-        Json(job).into_response()
-    } else {
-        StatusCode::NOT_FOUND.into_response()
-    }
-}
-
 #[derive(Serialize, sqlx::FromRow)]
 struct GetJobExtra {
     pub id: Uuid, // TODO - consistency in naming ids

--- a/src/server/api/project.rs
+++ b/src/server/api/project.rs
@@ -261,6 +261,7 @@ pub async fn delete(req: Request<State>) -> highnoon::Result<StatusCode> {
 struct ListJobQuery {
     limit: Option<u32>,
     after: Option<String>,
+    name: Option<String>,
 }
 
 #[derive(Serialize, sqlx::FromRow)]
@@ -326,11 +327,13 @@ pub async fn list_jobs(req: Request<State>) -> highnoon::Result<impl Responder> 
         LEFT OUTER JOIN job_stats js ON j.id = js.job_id
         WHERE project_id = $1
         AND ($2 IS NULL OR name > $2)
+        AND ($3 IS NULL OR name = $3)
         ORDER BY name
-        LIMIT $3",
+        LIMIT $4",
     )
     .bind(&id)
     .bind(query.after.as_ref())
+    .bind(query.name.as_ref())
     .bind(query.limit.unwrap_or(50))
     .fetch_all(&req.get_pool())
     .await?;

--- a/tests/test_project_jobs.rs
+++ b/tests/test_project_jobs.rs
@@ -1,0 +1,142 @@
+use highnoon::StatusCode;
+use pretty_assertions::assert_eq;
+use serde_json::{json, Value};
+use waterwheel::config;
+use waterwheel::server::api::make_app;
+use waterwheel::server::Server;
+
+mod common;
+
+#[tokio::main]
+#[test]
+
+pub async fn test_project_jobs() -> highnoon::Result<()> {
+    common::with_external_services(|| async {
+        let config = config::load()?;
+        let server = Server::new(config).await?;
+
+        let tc = make_app(&server).await?.test();
+
+        let project_uuid = "00000000-0000-0000-0000-000000000000";
+        let project_name = "integration_tests";
+
+        // CREATE A PROJECT
+        let resp = tc
+            .post("/api/projects")
+            .json(json!({
+              "uuid": project_uuid,
+              "name": project_name,
+              "description": "Project used for integration tests"
+            }))?
+            .send()
+            .await?;
+
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        // CREATE A JOB
+        let job1_uuid = "00000000-0000-0000-0000-000000000001";
+        let job1_name = "test_job_1";
+        let job1 = json!({
+            "uuid": job1_uuid,
+            "name": job1_name,
+            "project": project_name,
+            "description": "A test job",
+            "paused": false,
+            "triggers": [],
+            "tasks": [],
+        });
+
+        let resp = tc.post("/api/jobs").json(job1)?.send().await?;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        // CREATE ANOTHER JOB
+        let job2_uuid = "00000000-0000-0000-0000-000000000002";
+        let job2_name = "test_job_2";
+        let job2 = json!({
+            "uuid": job2_uuid,
+            "name": job2_name,
+            "project": project_name,
+            "description": "A test job",
+            "paused": false,
+            "triggers": [],
+            "tasks": [],
+        });
+
+        let resp = tc.post("/api/jobs").json(job2)?.send().await?;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        // LIST JOBS
+        let mut resp = tc
+            .get(format!("/api/projects/{}/jobs", project_uuid))
+            .send()
+            .await?;
+        let job_list: Value = resp.body_json().await?;
+        let expected_list = json!([
+            {
+                "job_id": job1_uuid,
+                "name": job1_name,
+                "description": "A test job",
+                "paused": false,
+                "success": 0,
+                "running": 0,
+                "failure": 0,
+                "waiting": 0,
+                "error": 0,
+            },
+            {
+                "job_id": job2_uuid,
+                "name": job2_name,
+                "description": "A test job",
+                "paused": false,
+                "success": 0,
+                "running": 0,
+                "failure": 0,
+                "waiting": 0,
+                "error": 0,
+            },
+        ]);
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(job_list, expected_list);
+
+        // GET A JOB BY NAME
+        let mut resp = tc
+            .get(format!(
+                "/api/projects/{}/jobs?name={}",
+                project_uuid, job1_name
+            ))
+            .send()
+            .await?;
+        let job_list: Value = resp.body_json().await?;
+        let expected_list = json!([
+            {
+                "job_id": job1_uuid,
+                "name": job1_name,
+                "description": "A test job",
+                "paused": false,
+                "success": 0,
+                "running": 0,
+                "failure": 0,
+                "waiting": 0,
+                "error": 0,
+            },
+        ]);
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(job_list, expected_list);
+
+        // GET A NON-EXISTENT JOB BY NAME
+        let mut resp = tc
+            .get(format!(
+                "/api/projects/{}/jobs?name={}",
+                project_uuid, "idontexist"
+            ))
+            .send()
+            .await?;
+        let job_list: Value = resp.body_json().await?;
+        let expected_list = json!([]);
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(job_list, expected_list);
+
+        Ok(())
+    })
+    .await
+}


### PR DESCRIPTION
# Description
 - Delete the `GET /api/jobs` endpoint as discussed in #2 
 - Add a `?name=my_job_name` filter to `/api/projects/.../jobs` in order to match functionality. This filters for jobs in the project matching that name. This functionality may be useful for searches based on job name.

## Notes
 - No check if made for the `?name` param simultaneously existing with the `?after` param, although it does not seem sensible to use these in the same request.
 - The endpoint returns `[{my_job_object}]` (in an array) even if there is only one match
 - The endpoint returns `[]` and `200 OK` if no job with the given match is found.

# Testing

 - A integration test has been written to test this functionality.